### PR TITLE
estimateGas dynamically calculation

### DIFF
--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -129,9 +129,14 @@ export class ChainManager {
     let gasEstimate;
     if (tx.gasLimit === undefined) {
       // Using current balance as limit for estimation
-      gasEstimate = (await this.provider.estimateGas(tx)) * 11n / 10n; // 10% buffer
+      const txWithLimit = { ...tx, gasLimit: 1_000_000 };
+      console.log("The gas limit is undefined, using current 1Mil as limit for estimation:", txWithLimit.gasLimit);
+      // Since the gas is being estimated, with binary search, we can use a relative low gas limit 
+      // to avoid wasting gas on the estimation itself
+      // In the worst case, the gas limit will be increased to the estimated value - dynamically
+      gasEstimate = await this.provider.estimateGas(txWithLimit);
     } else {
-      // console.log("using given gaslimit for estimation:", tx.gasLimit);
+      console.log("Using given gaslimit for estimation:", tx.gasLimit);
       gasEstimate = await this.provider.estimateGas(tx);
     }
 

--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -129,7 +129,7 @@ export class ChainManager {
     let gasEstimate;
     if (tx.gasLimit === undefined) {
       // Using current balance as limit for estimation
-      gasEstimate = await this.provider.estimateGas({...tx, gasLimit: this.balance});
+      gasEstimate = (await this.provider.estimateGas(tx)) * BigInt(11) / BigInt(10); // 10% buffer
     } else {
       // console.log("using given gaslimit for estimation:", tx.gasLimit);
       gasEstimate = await this.provider.estimateGas(tx);

--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -129,7 +129,7 @@ export class ChainManager {
     let gasEstimate;
     if (tx.gasLimit === undefined) {
       // Using current balance as limit for estimation
-      gasEstimate = (await this.provider.estimateGas(tx)) * BigInt(11) / BigInt(10); // 10% buffer
+      gasEstimate = (await this.provider.estimateGas(tx)) * 11n / 10n; // 10% buffer
     } else {
       // console.log("using given gaslimit for estimation:", tx.gasLimit);
       gasEstimate = await this.provider.estimateGas(tx);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "module": "ES6",
+    "target": "ES2020",
+    "module": "ES2020",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
Avoid gussing the limit, just let the estimateGas dynamically calculate add 10% buffer - later on all the restrictions are being enforced