### PR TITLE
fix masFeePerGas calculation

### DIFF
--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -291,7 +291,8 @@ export class ChainManager {
       }
       // Return only EIP-1559 fields
       const maxPriorityFeePerGas = Number(priorityFee) * multiplier;
-      const maxFeePerGas = Number(baseFee) + maxPriorityFeePerGas;
+      // https://www.blocknative.com/blog/eip-1559-fees see for more details
+      const maxFeePerGas = 2 * Number(baseFee) + maxPriorityFeePerGas;
       return {
         maxFeePerGas: BigInt(maxFeePerGas),
         maxPriorityFeePerGas: BigInt(maxPriorityFeePerGas),


### PR DESCRIPTION
https://www.blocknative.com/blog/eip-1559-fees In this article, ephesize the possibility that a base fee will be increased everytime a mined block was full, the next block base fee will increase:
![image](https://github.com/user-attachments/assets/a0af7eb8-132d-4e0d-9695-4d1c2d179623)

So In order to cope with this, we should multiply the base by 2 and add the maxPriorityPerGas, that way we'll secure our transaction for 6 consecutive full blocks. As listed in the article.

Probably in stressed environements (wtih full blocks, over time, the base fee can catach us.. ) so heuristically 6 blocks should be sufficient for each transaction.