### PR TITLE
fixed leaked unhandled promise

### DIFF
--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -180,8 +180,8 @@ export class ChainManager {
   private async syncNonce(): Promise<void> {
     if (this.nonce === null || this.nonce === undefined) {
       this.nonceSyncing = this.provider.getTransactionCount(this.wallet.address, "pending");
-      this.latestNonce = await this.provider.getTransactionCount(this.wallet.address, "latest");
       this.nonce = await this.nonceSyncing;
+      this.latestNonce = await this.provider.getTransactionCount(this.wallet.address, "latest");
 
       this.logger.info("chainManager nonce synced", {chainId: this.chainId, nonce: this.nonce, latestNonce: this.latestNonce});
     }


### PR DESCRIPTION
on syncNonce there are two rpc requests. There is a problem if the provider throws an rpcError twice in a row, since the first one was not being awaited, and so the second one, which was awaited, failed and got out of the `try` context, and then the first one failed before being `await`ed anywhere.


chatGPT explanation:
1. `this.nonceSyncing` stores a **Promise** that is rejected (but not yet awaited).
2. You immediately await a **different** Promise (`this.provider.getTransactionCount(..., "latest")`), which also rejects.
3. The rejected Promise in `nonceSyncing` is still pending in the background.
4. You then `await this.nonceSyncing`, which now throws.

But **if the first rejected Promise settles before you hit the `await this.nonceSyncing` line**, it becomes an **unhandled rejection**, since no `await` or `.catch()` has been attached **by that point**.