### PR TITLE
Better handling of timeout errors to avoid false success assumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx-sender",
-  "version": "1.1.3-alpha.1",
+  "version": "1.1.3-alpha.2",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx-sender",
-  "version": "1.1.3-alpha.3",
+  "version": "1.1.3-alpha.4",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx-sender",
-  "version": "1.1.3-alpha.4",
+  "version": "1.1.3",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx-sender",
-  "version": "1.1.3-alpha.2",
+  "version": "1.1.3-alpha.3",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx-sender",
-  "version": "1.1.2",
+  "version": "1.1.3-alpha.1",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -163,7 +163,7 @@ export class ChainManager {
 
   private logSuccessUnstuckedTx(txResponse: TransactionResponse, initial: boolean = false, eventId: number = 0, telemetryFunction: TxTelemetryFunction | null = null): void {
     if (telemetryFunction) {
-      telemetryFunction(eventId, `transaction_success_unstucked_${initial ? "init" : "retry"}_${txResponse.hash}`, this.chainId ?? 0, txResponse.to?.toString() ?? "", txResponse.nonce);
+      telemetryFunction(eventId, `transaction_succeeded_unstucked_${initial ? "init" : "retry"}_${txResponse.hash}`, this.chainId ?? 0, txResponse.to?.toString() ?? "", txResponse.nonce);
     }
     if (txResponse.maxFeePerGas) {
       this.logger.info("chainManager unstuck transaction", {txType: initial ? "init" : "retry", nonce: txResponse.nonce, fee: txResponse.maxFeePerGas, data: txResponse.data});

--- a/src/chainManager.ts
+++ b/src/chainManager.ts
@@ -1,6 +1,6 @@
 import { Wallet, JsonRpcProvider, TransactionRequest, TransactionResponse, sha256 } from "ethers";
-import { formatEther, parseEther, getBigInt } from "ethers";
-import { error, Logger } from "winston";
+import { parseEther, getBigInt } from "ethers";
+import { Logger } from "winston";
 const BLOCK_TIME = 13000; // 13 seconds, typical Ethereum block time is 12-13 seconds
 
 /**

--- a/src/transactionManager.ts
+++ b/src/transactionManager.ts
@@ -72,6 +72,16 @@ export class TransactionManager {
     return new TransactionManager(config as TransactionManagerConfig);
   }
 
+  public async getNonce(chain?: string): Promise<number> {
+    let chainManager = this.getChainManager(chain);
+    return chainManager.readNonce();
+  }
+
+  public forceNonceSync(chain?: string): void {
+    let chainManager = this.getChainManager(chain);
+    chainManager.forceNonceSync();
+  }
+
   /**
    * Prepares and signs a transaction.
    */

--- a/src/transactionManager.ts
+++ b/src/transactionManager.ts
@@ -72,7 +72,7 @@ export class TransactionManager {
     return new TransactionManager(config as TransactionManagerConfig);
   }
 
-  public async getNonce(chain: string): Promise<number> {
+  public getNonce(chain: string): number {
     let chainManager = this.getChainManager(chain);
     return chainManager.readNonce();
   }

--- a/src/transactionManager.ts
+++ b/src/transactionManager.ts
@@ -72,12 +72,12 @@ export class TransactionManager {
     return new TransactionManager(config as TransactionManagerConfig);
   }
 
-  public async getNonce(chain?: string): Promise<number> {
+  public async getNonce(chain: string): Promise<number> {
     let chainManager = this.getChainManager(chain);
     return chainManager.readNonce();
   }
 
-  public forceNonceSync(chain?: string): void {
+  public forceNonceSync(chain: string): void {
     let chainManager = this.getChainManager(chain);
     chainManager.forceNonceSync();
   }


### PR DESCRIPTION
Things that are getting fixed in this PR:

1. Distinguish between non-existing tx and tx that is stuck in mempool upon timout
2. Upon nonce too low we should force nonce sync
3. Support nonce querying and forecful nonce sync by the aggregator


Thinks that are not addressed in this PR but might be an issue:
1. After a stuck in mempool tx we might have a "nonce too low" if the tx is out of the mempool before we were able to send the replacement tx, we might need to avoid sending another tx (after syncing nonce) - need to test it, currently the only harm is double tx